### PR TITLE
Configurable splash screen, disabled by default

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -1,7 +1,7 @@
 {
   "uuid": "55f7744b-f586-45b8-854c-554f34489f20",
   "shortName": "Timely",
-  "longName": "Timely 2.5",
+  "longName": "Timely 2.5.1",
   "companyName": "Martin Norland (@cynorg)",
   "versionCode": 2,
   "versionLabel": "2.5",
@@ -47,6 +47,7 @@
     "idle_stop":            34,
     "weather_fmt":          35,
     "weather_update":       36,
+    "show_splash":          37,
 
     "message_type":         99,
     "send_batt_percent":   100,

--- a/src/Timely.c
+++ b/src/Timely.c
@@ -217,6 +217,7 @@ weather_data weather = {
 persist settings = {
   .version    = 12,
   .inverted   = 0, // no, dark
+  .show_splash = 0, // show splash screen on start
   .day_invert = 1, // yes
   .grid       = 1, // yes
   .vibe_hour  = 0, // no
@@ -1447,14 +1448,17 @@ static void window_load(Window *window) {
   calendar_layer = layer_create(slot_bot_bounds);
   layer_set_update_proc(calendar_layer, calendar_layer_update_callback);
   layer_add_child(slot_bot, calendar_layer);
-  layer_set_hidden(calendar_layer, true);
-
   splash_layer = layer_create(slot_bot_bounds);
-  layer_set_update_proc(splash_layer, splash_layer_update_callback);
-  layer_add_child(slot_bot, splash_layer);
 
-  toggle_slot_bottom((void*)splash_layer);  // show @ start...
-  bottom_toggle = app_timer_register(2000, &toggle_slot_bottom, (void*)calendar_layer); // queue calendar to reappear in 2 seconds
+  if (settings.show_splash) {
+    layer_set_hidden(calendar_layer, true);
+
+    layer_set_update_proc(splash_layer, splash_layer_update_callback);
+    layer_add_child(slot_bot, splash_layer);
+
+    toggle_slot_bottom((void*)splash_layer);  // show @ start...
+    bottom_toggle = app_timer_register(2000, &toggle_slot_bottom, (void*)calendar_layer); // queue calendar to reappear in 2 seconds
+  }
 
   date_layer = text_layer_create( GRect(REL_CLOCK_DATE_LEFT, REL_CLOCK_DATE_TOP, REL_CLOCK_DATE_WIDTH, REL_CLOCK_DATE_HEIGHT) ); // see position_date_layer()
   set_layer_attr_sfont(date_layer, FONT_KEY_GOTHIC_24, GTextAlignmentCenter);

--- a/src/Timely.h
+++ b/src/Timely.h
@@ -7,6 +7,7 @@ typedef struct persist { // 18 bytes
   uint8_t version;                // version key
   uint8_t inverted;               // Invert display
   uint8_t day_invert;             // Invert colors on today's date
+  uint8_t show_splash;            // Show the splash screen
   uint8_t grid;                   // Show the grid
   uint8_t vibe_hour;              // vibrate at the top of the hour?
   uint8_t dayOfWeekOffset;        // first day of our week

--- a/src/js/configuration.html
+++ b/src/js/configuration.html
@@ -88,6 +88,14 @@
         <label for="key12-7">Ow</label>
 </fieldset>
 
+<fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
+    <legend>Show splash screen:</legend>
+        <input name="key37" id="key37-1" value="1" checked="checked" type="radio">
+        <label for="key37-1">Yes</label>
+        <input name="key37" id="key37-0" value="0" type="radio">
+        <label for="key37-0">No</label>
+</fieldset>
+
     </div>
     <div data-role="collapsible">
         <h3>Translations</h3>
@@ -335,6 +343,7 @@
       function saveOptions() {
         var options = {
           'style_inv':     Number( $("input[name=key0]:checked").val() ),
+          'show_splash':   Number( $("input[name=key37]:checked").val() ),
           'style_day_inv': Number( $("input[name=key1]:checked").val() ),
           'style_grid':    Number( $("input[name=key2]:checked").val() ),
           'vibe_hour':     Number( $("input[name=key3]:checked").val() ),
@@ -385,6 +394,8 @@
           // the Pebble webview dies on the next line...
           $("input[name=key0][id=key0-"+ls_pto["style_inv"]+"]").prop('checked',true);
           $("input[name=key0]").checkboxradio('refresh');
+          $("input[name=key37][id=key37-"+ls_pto["show_splash"]+"]").prop('checked',true);
+          $("input[name=key37]").checkboxradio('refresh');
           $("input[name=key1][id=key1-"+ls_pto["style_day_inv"]+"]").prop('checked',true);
           $("input[name=key1]").checkboxradio('refresh');
           $("input[name=key2][id=key2-"+ls_pto["style_grid"]+"]").prop('checked',true);


### PR DESCRIPTION
A persistent setting for displaying the splash screen is added. Since the configuration screen is not used from the repository, but from the Timely website, the screen is changed, but will not show up, hence the default of disabling the splash screen.
